### PR TITLE
Fix it to be able to be used as library

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: crystal-parsec
+name: parsec
 version: 0.0.1
 
 license: MIT


### PR DESCRIPTION
Thank you for your great project! 

I couldn't import `crystal-parsec` from another external shards project. So I fixed this problem.
Actually, I can use `crystal-parsec` from my repository [`nwtgck/parsec-prac-crystal`](https://github.com/nwtgck/parsec-prac-crystal) which uses my forked `crystal-parsec`.