### PR TITLE
Use crz 1.x

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ license: MIT
 dependencies:
   crz:
     git: https://github.com/dhruvrajvanshi/crz
-    version: ~> 0.2.0
+    tag: v1.0.0
 
 author:
   - Dhruv Rajvanshi <dhruvrajvanshi@outlook.com>


### PR DESCRIPTION
crz 0.2.0 causes syntax errors on latest Crystal. Bumping to 1.x fixes that. The `tag` was used rather than `version` as the github release appears to have been given a wrongly formatted name for the `version` to understand it.